### PR TITLE
Add a basic implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+/target
+/classes
+/checkouts
+profiles.clj
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+/.lein-*
+/.nrepl-port
+.hgignore
+.hg/
+.cpcache/

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,7 @@
+{:paths ["src" "resources"]
+ :deps {org.clojure/clojure {:mvn/version "1.10.0"}}
+ :aliases {:test {:extra-paths ["test" "dev"]
+                  :extra-deps {org.clojure/test.check {:mvn/version "0.9.0"}}
+                  :main-opts ["-m" "cognitect.test-runner"]}}
+ :mvn/repos {"central" {:url "https://repo1.maven.org/maven2/"}
+             "clojars" {:url "https://clojars.org/repo"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,12 @@
-{:paths ["src" "resources"]
- :deps {org.clojure/clojure {:mvn/version "1.10.0"}}
- :aliases {:test {:extra-paths ["test" "dev"]
-                  :extra-deps {org.clojure/test.check {:mvn/version "0.9.0"}}
-                  :main-opts ["-m" "cognitect.test-runner"]}}
- :mvn/repos {"central" {:url "https://repo1.maven.org/maven2/"}
-             "clojars" {:url "https://clojars.org/repo"}}}
+{:paths ["src" "resources"],
+ :deps
+ {org.clojure/clojure #:mvn{:version "1.10.0"},
+  org.apache.commons/commons-text #:mvn{:version "1.6"}},
+ :aliases
+ {:test
+  {:extra-paths ["test" "dev"],
+   :extra-deps #:org.clojure{test.check #:mvn{:version "0.9.0"}},
+   :main-opts ["-m" "cognitect.test-runner"]}},
+ :mvn/repos
+ {"central" {:url "https://repo1.maven.org/maven2/"},
+  "clojars" {:url "https://clojars.org/repo"}}}

--- a/src/spell-checker/dictionary.clj
+++ b/src/spell-checker/dictionary.clj
@@ -13,6 +13,8 @@
       slurp
       split-at-line-breaks
       (mapcat #(string/split % #"-"))
+      (filter #(>= (count %) 2))
+      (map string/lower-case)
       set))
 
 (defonce words (build-dictionary pt-br))

--- a/src/spell-checker/dictionary.clj
+++ b/src/spell-checker/dictionary.clj
@@ -1,0 +1,18 @@
+(ns spell-checker.dictionary
+  (:require [clojure.java.io :as io]
+            [clojure.string :as string]))
+
+(def pt-br "pt_BR.dic")
+
+(defn- split-at-line-breaks [text]
+  (string/split text (re-pattern (System/lineSeparator))))
+
+(defn- build-dictionary [dict-file]
+  (->> dict-file
+      io/resource
+      slurp
+      split-at-line-breaks
+      (mapcat #(string/split % #"-"))
+      set))
+
+(defonce words (build-dictionary pt-br))

--- a/src/spell-checker/levenshtein.clj
+++ b/src/spell-checker/levenshtein.clj
@@ -1,20 +1,7 @@
-(ns spell-checker.levenshtein)
+(ns spell-checker.levenshtein
+  (:import (org.apache.commons.text.similarity LevenshteinDistance)))
 
-(defn- cost [word-a word-b]
-  (if (= (last word-a) (last word-b))
-    0
-    1))
+(def ^:private levenshtein (LevenshteinDistance.))
 
-(declare distance)
-(defn- distance* [word-a word-b]
-  (let [cost (cost word-a word-b)]
-    (min
-     (inc (distance (subs word-a 0 (dec (count word-a))) word-b))
-     (inc (distance word-a (subs word-b 0 (dec (count word-b)))))
-     (+ cost (distance (subs word-a 0 (dec (count word-a))) (subs word-b 0 (dec (count word-b))))))))
-
-(defn- distance [word-a word-b]
-  (cond
-    (empty? word-a) (count word-b)
-    (empty? word-b) (count word-a)
-    :else (distance* word-a word-b)))
+(defn distance [word-a word-b]
+  (.apply levenshtein word-a word-b))

--- a/src/spell-checker/levenshtein.clj
+++ b/src/spell-checker/levenshtein.clj
@@ -1,0 +1,20 @@
+(ns spell-checker.levenshtein)
+
+(defn- cost [word-a word-b]
+  (if (= (last word-a) (last word-b))
+    0
+    1))
+
+(declare distance)
+(defn- distance* [word-a word-b]
+  (let [cost (cost word-a word-b)]
+    (min
+     (inc (distance (subs word-a 0 (dec (count word-a))) word-b))
+     (inc (distance word-a (subs word-b 0 (dec (count word-b)))))
+     (+ cost (distance (subs word-a 0 (dec (count word-a))) (subs word-b 0 (dec (count word-b))))))))
+
+(defn- distance [word-a word-b]
+  (cond
+    (empty? word-a) (count word-b)
+    (empty? word-b) (count word-a)
+    :else (distance* word-a word-b)))

--- a/src/spell-checker/solution.clj
+++ b/src/spell-checker/solution.clj
@@ -1,0 +1,16 @@
+(ns spell-checker.solution
+  (:require [spell-checker.dictionary :as dictionary]
+            [spell-checker.levenshtein :as levenshtein]))
+
+(defn check-spelling [dict word]
+  (if (dict word)
+    {:result :correct-word}
+    {:result     :misspelled-word
+     :suggestion (apply min-key (partial levenshtein/distance word) dict)}))
+
+(comment
+  "Evaluate the forms bellow to see the results"
+  (check-spelling dictionary/words "cavalo")
+  (check-spelling dictionary/words "viajem")
+  (check-spelling dictionary/words "viajen")
+  (check-spelling dictionary/words "vakaa"))


### PR DESCRIPTION
This is an initial implementation with the following items:
* A distance function that determines the Levenshtein distance for two words - I
had written a purely Clojure implementation based on mutual recurssion, but the
performance was terrible and I decided to use commons-text to avoid wasting time
with that.
* A ns that builds the dictionary from the file pointed by Karen. I`ve written a
simple logic to clean the dictionary by removing useless tokens.
* A basic solution that combines the two previous namespaces and return a result
indicating whether a given word is correct or misspelled. When misspelled, a
better suggestion is returned - perhaps we can return more than one word, but
this would involve writting a more sophisticated code to sort words according to
their Levenshtein score. Not sure whether we want to do that.